### PR TITLE
Modernize portfolio with minimalist dark theme

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,8 +1,2 @@
-remote-theme: jekyll/minima
-
-theme: jekyll-theme-minimal
-
 title: Nima Azbijari
-logo: IMG_1481.jpeg
-
-description: Twitter @nazbijar
+description: AI researcher — deep learning & computational biology. Twitter @nazbijar

--- a/index.html
+++ b/index.html
@@ -1,0 +1,355 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Nima Azbijari</title>
+  <meta name="description" content="Nima Azbijari — AI researcher working on deep learning and computational biology." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+  <style>
+    :root {
+      --bg: #0b0c0e;
+      --bg-elev: #131519;
+      --border: #24272e;
+      --text: #e8e9ec;
+      --text-dim: #a1a5ad;
+      --text-faint: #6b6f78;
+      --accent: #5eead4;
+      --accent-dim: rgba(94, 234, 212, 0.12);
+      --radius: 14px;
+      --maxw: 720px;
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    html { scroll-behavior: smooth; }
+
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.65;
+      -webkit-font-smoothing: antialiased;
+      font-feature-settings: "cv02", "cv03", "cv04", "cv11";
+      background-image: radial-gradient(circle at 50% -10%, rgba(94, 234, 212, 0.06), transparent 45%);
+      background-repeat: no-repeat;
+    }
+
+    a { color: var(--accent); text-decoration: none; transition: color .18s ease, opacity .18s ease; }
+    a:hover { opacity: .82; }
+
+    .wrap {
+      max-width: var(--maxw);
+      margin: 0 auto;
+      padding: 0 24px;
+    }
+
+    /* ---------- Nav ---------- */
+    nav {
+      position: sticky;
+      top: 0;
+      z-index: 10;
+      backdrop-filter: blur(10px);
+      background: rgba(11, 12, 14, 0.72);
+      border-bottom: 1px solid var(--border);
+    }
+    nav .wrap {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      height: 60px;
+    }
+    nav .brand { font-weight: 600; letter-spacing: -.01em; color: var(--text); }
+    nav .links { display: flex; gap: 22px; font-size: .9rem; }
+    nav .links a { color: var(--text-dim); }
+    nav .links a:hover { color: var(--text); opacity: 1; }
+    @media (max-width: 560px) { nav .links { display: none; } }
+
+    /* ---------- Hero ---------- */
+    header.hero {
+      padding: 72px 0 40px;
+      display: flex;
+      align-items: center;
+      gap: 32px;
+    }
+    .avatar {
+      flex: 0 0 auto;
+      width: 116px;
+      height: 116px;
+      border-radius: 50%;
+      object-fit: cover;
+      object-position: center 22%;
+      border: 1px solid var(--border);
+      filter: grayscale(1) contrast(1.02);
+      transition: filter .3s ease;
+    }
+    .avatar:hover { filter: grayscale(0) contrast(1); }
+    .hero h1 {
+      font-size: 2rem;
+      font-weight: 700;
+      letter-spacing: -.02em;
+      line-height: 1.1;
+      margin-bottom: 8px;
+    }
+    .hero .role { color: var(--text-dim); font-size: 1.02rem; }
+    .hero .socials { margin-top: 14px; display: flex; gap: 16px; font-size: .88rem; }
+    .hero .socials a { color: var(--text-dim); display: inline-flex; align-items: center; gap: 6px; }
+    .hero .socials a:hover { color: var(--accent); opacity: 1; }
+    @media (max-width: 560px) {
+      header.hero { flex-direction: column; align-items: flex-start; gap: 22px; padding: 52px 0 32px; }
+      .hero h1 { font-size: 1.7rem; }
+    }
+
+    /* ---------- Sections ---------- */
+    section { padding: 30px 0; border-top: 1px solid var(--border); }
+    .section-title {
+      font-size: .78rem;
+      text-transform: uppercase;
+      letter-spacing: .16em;
+      color: var(--text-faint);
+      font-weight: 600;
+      margin-bottom: 22px;
+    }
+
+    p { color: var(--text-dim); }
+    p + p { margin-top: 14px; }
+
+    /* ---------- Timeline entries ---------- */
+    .entry { margin-bottom: 22px; }
+    .entry:last-child { margin-bottom: 0; }
+    .entry .top {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      gap: 16px;
+      flex-wrap: wrap;
+    }
+    .entry .title { font-weight: 600; color: var(--text); }
+    .entry .date {
+      font-family: "JetBrains Mono", monospace;
+      font-size: .78rem;
+      color: var(--text-faint);
+      white-space: nowrap;
+    }
+    .entry .sub { color: var(--text-dim); font-size: .95rem; margin-top: 3px; }
+
+    /* ---------- Projects ---------- */
+    .projects { display: grid; gap: 14px; }
+    .card {
+      display: block;
+      background: var(--bg-elev);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 22px 24px;
+      transition: border-color .2s ease, transform .2s ease, background .2s ease;
+    }
+    .card:hover {
+      border-color: rgba(94, 234, 212, 0.4);
+      background: #16191e;
+      transform: translateY(-2px);
+      opacity: 1;
+    }
+    .card .card-head {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 8px;
+    }
+    .card h3 {
+      font-size: 1.05rem;
+      font-weight: 600;
+      color: var(--text);
+      letter-spacing: -.01em;
+    }
+    .card .arrow { color: var(--text-faint); transition: transform .2s ease, color .2s ease; }
+    .card:hover .arrow { color: var(--accent); transform: translate(2px, -2px); }
+    .card p { font-size: .92rem; line-height: 1.6; margin: 0; color: var(--text-dim); }
+
+    .tags { margin-top: 14px; display: flex; flex-wrap: wrap; gap: 8px; }
+    .tag {
+      font-family: "JetBrains Mono", monospace;
+      font-size: .7rem;
+      color: var(--accent);
+      background: var(--accent-dim);
+      border: 1px solid rgba(94, 234, 212, 0.18);
+      padding: 3px 9px;
+      border-radius: 999px;
+    }
+
+    /* ---------- Footer ---------- */
+    footer {
+      padding: 40px 0 60px;
+      border-top: 1px solid var(--border);
+      color: var(--text-faint);
+      font-size: .82rem;
+      display: flex;
+      justify-content: space-between;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+  </style>
+</head>
+<body>
+  <nav>
+    <div class="wrap">
+      <span class="brand">Nima Azbijari</span>
+      <div class="links">
+        <a href="#about">About</a>
+        <a href="#experience">Experience</a>
+        <a href="#education">Education</a>
+        <a href="#projects">Projects</a>
+      </div>
+    </div>
+  </nav>
+
+  <div class="wrap">
+    <header class="hero">
+      <img class="avatar" src="IMG_1481.jpeg" alt="Portrait of Nima Azbijari" />
+      <div>
+        <h1>Nima Azbijari</h1>
+        <div class="role">AI researcher — deep learning &amp; computational biology</div>
+        <div class="socials">
+          <a href="https://twitter.com/nazbijar" target="_blank" rel="noopener">Twitter ↗</a>
+          <a href="https://github.com/nimuh" target="_blank" rel="noopener">GitHub ↗</a>
+        </div>
+      </div>
+    </header>
+
+    <section id="about">
+      <div class="section-title">About</div>
+      <p>
+        I am passionate about artificial intelligence and using it to solve hard problems. My interests are
+        in deep learning and computational biology. I am currently a member of Dr. Maude David's Lab at
+        Oregon State University, where I work on protein language models as well as graph neural networks for
+        knowledge transfer from biological databases.
+      </p>
+      <p>
+        Outside of this incredible field, I enjoy surfing, playing chess, rock climbing, and hiking.
+      </p>
+    </section>
+
+    <section id="experience">
+      <div class="section-title">Experience</div>
+      <div class="entry">
+        <div class="top">
+          <span class="title">Absci AI Lab — AI Scientist Intern</span>
+          <span class="date">Jun 2022 – Aug 2022</span>
+        </div>
+        <div class="sub">Built deep learning models for drug discovery research.</div>
+      </div>
+    </section>
+
+    <section id="education">
+      <div class="section-title">Education</div>
+      <div class="entry">
+        <div class="top">
+          <span class="title">Oregon State University — Ph.D., Artificial Intelligence</span>
+          <span class="date">Present – 2026</span>
+        </div>
+        <div class="sub">Research focused on deep learning and computational biology. Advised by Dr. Maude David.</div>
+      </div>
+      <div class="entry">
+        <div class="top">
+          <span class="title">University of Hawaiʻi at Mānoa — M.Sc., Computer Science</span>
+          <span class="date">2021</span>
+        </div>
+        <div class="sub">Interpretable deep learning for genomic datasets. Advised by Dr. Mahdi Belcaid.</div>
+      </div>
+      <div class="entry">
+        <div class="top">
+          <span class="title">University of California, San Diego — B.Sc., Cognitive Science</span>
+          <span class="date">2018</span>
+        </div>
+        <div class="sub">Minor in Computer Science.</div>
+      </div>
+    </section>
+
+    <section id="projects">
+      <div class="section-title">Selected Projects</div>
+      <div class="projects">
+        <a class="card" href="https://github.com/nimuh/cancer-dl" target="_blank" rel="noopener">
+          <div class="card-head">
+            <h3>Genome Deep Learning</h3>
+            <span class="arrow">↗</span>
+          </div>
+          <p>
+            Predicting cancer risk across multiple cancer types from an individual's genotype, using data from
+            The Cancer Genome Atlas. I explored neural architectures beyond standard feed-forward networks,
+            landing on an encoder-based model that jointly learns a latent representation and a classifier. The
+            work surfaced deep entanglement between cancer types and motivated my capstone analysis of how
+            individual genomic loci contribute to classification.
+          </p>
+          <div class="tags">
+            <span class="tag">deep learning</span>
+            <span class="tag">genomics</span>
+            <span class="tag">representation learning</span>
+          </div>
+        </a>
+
+        <a class="card" href="https://drive.google.com/file/d/1cu25Det7OxyFogoY4xCjai3EWOHDV90n/view?usp=sharing" target="_blank" rel="noopener">
+          <div class="card-head">
+            <h3>Deep Learning Interpretability for Genomics</h3>
+            <span class="arrow">↗</span>
+          </div>
+          <p>
+            My M.Sc. focus, extending the genome work by testing whether class similarity can be extracted
+            from a learned network. Working across both simulated and real genomic data, I analyzed learned
+            network parameters to understand what useful, interpretable information a model reveals about the
+            underlying problem.
+          </p>
+          <div class="tags">
+            <span class="tag">interpretability</span>
+            <span class="tag">genomics</span>
+          </div>
+        </a>
+
+        <a class="card" href="https://github.com/nimuh/deep-learning" target="_blank" rel="noopener">
+          <div class="card-head">
+            <h3>Image Segmentation for Monocular Visual Odometry</h3>
+            <span class="arrow">↗</span>
+          </div>
+          <p>
+            My first step into computer vision. After a failed attempt at predicting vehicle speed from dashcam
+            frames, I turned to scene understanding — surveying classical segmentation methods and implementing
+            <a href="https://arxiv.org/abs/1511.00561" target="_blank" rel="noopener">SegNet</a> in PyTorch,
+            with Weights &amp; Biases for monitoring and a GTX 1660 Super for training.
+          </p>
+          <div class="tags">
+            <span class="tag">computer vision</span>
+            <span class="tag">segmentation</span>
+            <span class="tag">PyTorch</span>
+          </div>
+        </a>
+
+        <a class="card" href="https://github.com/nimuh/StructuralBalanceInR" target="_blank" rel="noopener">
+          <div class="card-head">
+            <h3>Structural Balance in R</h3>
+            <span class="arrow">↗</span>
+          </div>
+          <p>
+            A library for computing the structural balance of signed graphs, optimizing R with C++ for
+            large-scale graph computation. We designed the balance algorithm from scratch; I wrote the C++ core
+            powering the heavy graph computations.
+          </p>
+          <div class="tags">
+            <span class="tag">graphs</span>
+            <span class="tag">C++</span>
+            <span class="tag">R</span>
+          </div>
+        </a>
+      </div>
+    </section>
+
+    <footer>
+      <span>© <span id="year"></span> Nima Azbijari</span>
+      <span>Built with care · <a href="https://github.com/nimuh/nimuh.github.io" target="_blank" rel="noopener">source</a></span>
+    </footer>
+  </div>
+
+  <script>
+    document.getElementById("year").textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Replaces the light Jekyll theme (rendering `README.md` through `jekyll-theme-minimal`) with a self-contained, modern **dark** homepage.

## Changes
- **`index.html`** (new): self-contained dark-theme page served verbatim by GitHub Pages (no Jekyll front matter, so it bypasses the old theme).
  - Near-black palette with a subtle teal accent and top glow
  - Sticky blurred nav, circular B&W portrait (grayscale → color on hover)
  - Timeline-style Experience/Education, project cards with tech tags + hover animation
  - Fully responsive; Inter + JetBrains Mono
- **`_config.yml`**: trimmed to `title`/`description` (removed unused theme declarations)
- `README.md` left unchanged so it still reads well on GitHub

Content copied faithfully from `README.md`, lightly tightened for the web.

🤖 Generated with [Claude Code](https://claude.com/claude-code)