### PR TITLE
Add Research page and shared stylesheet

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,198 +8,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
-  <style>
-    :root {
-      --bg: #0b0c0e;
-      --bg-elev: #131519;
-      --border: #24272e;
-      --text: #e8e9ec;
-      --text-dim: #a1a5ad;
-      --text-faint: #6b6f78;
-      --accent: #5eead4;
-      --accent-dim: rgba(94, 234, 212, 0.12);
-      --radius: 14px;
-      --maxw: 720px;
-    }
-
-    * { box-sizing: border-box; margin: 0; padding: 0; }
-
-    html { scroll-behavior: smooth; }
-
-    body {
-      background: var(--bg);
-      color: var(--text);
-      font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-      line-height: 1.65;
-      -webkit-font-smoothing: antialiased;
-      font-feature-settings: "cv02", "cv03", "cv04", "cv11";
-      background-image: radial-gradient(circle at 50% -10%, rgba(94, 234, 212, 0.06), transparent 45%);
-      background-repeat: no-repeat;
-    }
-
-    a { color: var(--accent); text-decoration: none; transition: color .18s ease, opacity .18s ease; }
-    a:hover { opacity: .82; }
-
-    .wrap {
-      max-width: var(--maxw);
-      margin: 0 auto;
-      padding: 0 24px;
-    }
-
-    /* ---------- Nav ---------- */
-    nav {
-      position: sticky;
-      top: 0;
-      z-index: 10;
-      backdrop-filter: blur(10px);
-      background: rgba(11, 12, 14, 0.72);
-      border-bottom: 1px solid var(--border);
-    }
-    nav .wrap {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      height: 60px;
-    }
-    nav .brand { font-weight: 600; letter-spacing: -.01em; color: var(--text); }
-    nav .links { display: flex; gap: 22px; font-size: .9rem; }
-    nav .links a { color: var(--text-dim); }
-    nav .links a:hover { color: var(--text); opacity: 1; }
-    @media (max-width: 560px) { nav .links { display: none; } }
-
-    /* ---------- Hero ---------- */
-    header.hero {
-      padding: 72px 0 40px;
-      display: flex;
-      align-items: center;
-      gap: 32px;
-    }
-    .avatar {
-      flex: 0 0 auto;
-      width: 116px;
-      height: 116px;
-      border-radius: 50%;
-      object-fit: cover;
-      object-position: center 22%;
-      border: 1px solid var(--border);
-      filter: grayscale(1) contrast(1.02);
-      transition: filter .3s ease;
-    }
-    .avatar:hover { filter: grayscale(0) contrast(1); }
-    .hero h1 {
-      font-size: 2rem;
-      font-weight: 700;
-      letter-spacing: -.02em;
-      line-height: 1.1;
-      margin-bottom: 8px;
-    }
-    .hero .role { color: var(--text-dim); font-size: 1.02rem; }
-    .hero .socials { margin-top: 14px; display: flex; gap: 16px; font-size: .88rem; }
-    .hero .socials a { color: var(--text-dim); display: inline-flex; align-items: center; gap: 6px; }
-    .hero .socials a:hover { color: var(--accent); opacity: 1; }
-    @media (max-width: 560px) {
-      header.hero { flex-direction: column; align-items: flex-start; gap: 22px; padding: 52px 0 32px; }
-      .hero h1 { font-size: 1.7rem; }
-    }
-
-    /* ---------- Sections ---------- */
-    section { padding: 30px 0; border-top: 1px solid var(--border); }
-    .section-title {
-      font-size: .78rem;
-      text-transform: uppercase;
-      letter-spacing: .16em;
-      color: var(--text-faint);
-      font-weight: 600;
-      margin-bottom: 22px;
-    }
-
-    p { color: var(--text-dim); }
-    p + p { margin-top: 14px; }
-
-    /* ---------- Timeline entries ---------- */
-    .entry { margin-bottom: 22px; }
-    .entry:last-child { margin-bottom: 0; }
-    .entry .top {
-      display: flex;
-      justify-content: space-between;
-      align-items: baseline;
-      gap: 16px;
-      flex-wrap: wrap;
-    }
-    .entry .title { font-weight: 600; color: var(--text); }
-    .entry .date {
-      font-family: "JetBrains Mono", monospace;
-      font-size: .78rem;
-      color: var(--text-faint);
-      white-space: nowrap;
-    }
-    .entry .sub { color: var(--text-dim); font-size: .95rem; margin-top: 3px; }
-
-    /* ---------- Projects ---------- */
-    .projects { display: grid; gap: 14px; }
-    .card {
-      display: block;
-      background: var(--bg-elev);
-      border: 1px solid var(--border);
-      border-radius: var(--radius);
-      padding: 22px 24px;
-      transition: border-color .2s ease, transform .2s ease, background .2s ease;
-    }
-    .card:hover {
-      border-color: rgba(94, 234, 212, 0.4);
-      background: #16191e;
-      transform: translateY(-2px);
-      opacity: 1;
-    }
-    .card .card-head {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-      margin-bottom: 8px;
-    }
-    .card h3 {
-      font-size: 1.05rem;
-      font-weight: 600;
-      color: var(--text);
-      letter-spacing: -.01em;
-    }
-    .card .arrow { color: var(--text-faint); transition: transform .2s ease, color .2s ease; }
-    .card:hover .arrow { color: var(--accent); transform: translate(2px, -2px); }
-    .card p { font-size: .92rem; line-height: 1.6; margin: 0; color: var(--text-dim); }
-
-    .tags { margin-top: 14px; display: flex; flex-wrap: wrap; gap: 8px; }
-    .tag {
-      font-family: "JetBrains Mono", monospace;
-      font-size: .7rem;
-      color: var(--accent);
-      background: var(--accent-dim);
-      border: 1px solid rgba(94, 234, 212, 0.18);
-      padding: 3px 9px;
-      border-radius: 999px;
-    }
-
-    /* ---------- Footer ---------- */
-    footer {
-      padding: 40px 0 60px;
-      border-top: 1px solid var(--border);
-      color: var(--text-faint);
-      font-size: .82rem;
-      display: flex;
-      justify-content: space-between;
-      flex-wrap: wrap;
-      gap: 10px;
-    }
-  </style>
+  <link rel="stylesheet" href="style.css" />
 </head>
 <body>
   <nav>
     <div class="wrap">
-      <span class="brand">Nima Azbijari</span>
+      <a class="brand" href="index.html">Nima Azbijari</a>
       <div class="links">
         <a href="#about">About</a>
         <a href="#experience">Experience</a>
         <a href="#education">Education</a>
         <a href="#projects">Projects</a>
+        <a href="research.html">Research</a>
       </div>
     </div>
   </nav>
@@ -268,7 +88,7 @@
 
     <section id="projects">
       <div class="section-title">Selected Projects</div>
-      <div class="projects">
+      <div class="cards">
         <a class="card" href="https://github.com/nimuh/cancer-dl" target="_blank" rel="noopener">
           <div class="card-head">
             <h3>Genome Deep Learning</h3>

--- a/research.html
+++ b/research.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Research — Nima Azbijari</title>
+  <meta name="description" content="Research by Nima Azbijari — protein language models, graph neural networks, and computational biology." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <nav>
+    <div class="wrap">
+      <a class="brand" href="index.html">Nima Azbijari</a>
+      <div class="links">
+        <a href="index.html#about">About</a>
+        <a href="index.html#experience">Experience</a>
+        <a href="index.html#education">Education</a>
+        <a href="index.html#projects">Projects</a>
+        <a href="research.html" class="active">Research</a>
+      </div>
+    </div>
+  </nav>
+
+  <div class="wrap">
+    <header class="page-header">
+      <h1>Research</h1>
+      <p>Work from my Ph.D. and M.Sc., spanning protein language models, graph neural networks, and genomic deep learning.</p>
+    </header>
+
+    <section id="current">
+      <div class="section-title">Current</div>
+      <div class="cards">
+        <div class="card-static">
+          <div class="status"><span class="dot"></span>ongoing · Oregon State University</div>
+          <h3>Protein Language Models</h3>
+          <p>
+            Large-scale language models pre-trained on protein sequences have shown remarkable ability to capture
+            evolutionary and structural information. My current work investigates how these representations can
+            be adapted and fine-tuned for downstream tasks in computational biology — particularly in contexts
+            where labeled data is scarce.
+          </p>
+          <div class="tags">
+            <span class="tag">protein LMs</span>
+            <span class="tag">transfer learning</span>
+            <span class="tag">computational biology</span>
+          </div>
+        </div>
+
+        <div class="card-static">
+          <div class="status"><span class="dot"></span>ongoing · Oregon State University</div>
+          <h3>Graph Neural Networks for Biological Knowledge Transfer</h3>
+          <p>
+            Biological databases encode rich, structured knowledge about proteins, pathways, and interactions.
+            I am developing graph neural network frameworks that can leverage this structured knowledge to
+            improve model performance and generalization, particularly for tasks where experimental labels
+            are expensive or limited.
+          </p>
+          <div class="tags">
+            <span class="tag">GNNs</span>
+            <span class="tag">knowledge graphs</span>
+            <span class="tag">drug discovery</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="past">
+      <div class="section-title">Past</div>
+      <div class="cards">
+        <a class="card" href="https://drive.google.com/file/d/1cu25Det7OxyFogoY4xCjai3EWOHDV90n/view?usp=sharing" target="_blank" rel="noopener">
+          <div class="card-head">
+            <h3>Deep Learning Interpretability for Genomics</h3>
+            <span class="arrow">↗</span>
+          </div>
+          <p>
+            M.Sc. thesis at the University of Hawaiʻi at Mānoa (2021). I tested whether a classifier trained
+            on genomic data encodes class similarity in its learned representations — experimenting on both
+            simulated and real data from The Cancer Genome Atlas. By analyzing the learned parameters directly,
+            I explored whether neural networks can surface biologically meaningful structure beyond their
+            primary classification objective.
+          </p>
+          <div class="tags">
+            <span class="tag">interpretability</span>
+            <span class="tag">genomics</span>
+            <span class="tag">representation learning</span>
+          </div>
+        </a>
+
+        <a class="card" href="https://github.com/nimuh/cancer-dl" target="_blank" rel="noopener">
+          <div class="card-head">
+            <h3>Cancer Risk Prediction from Genotype</h3>
+            <span class="arrow">↗</span>
+          </div>
+          <p>
+            Multi-cancer risk prediction from individual genotype data using The Cancer Genome Atlas.
+            A standard feed-forward network failed to generalize; the best-performing model was an
+            encoder-based architecture that jointly learns a latent representation and a classifier.
+            Analysis revealed deep entanglement between cancer types in the latent space, motivating
+            further interpretability work on which genomic loci drive classification.
+          </p>
+          <div class="tags">
+            <span class="tag">deep learning</span>
+            <span class="tag">genomics</span>
+            <span class="tag">encoder architectures</span>
+          </div>
+        </a>
+
+        <a class="card" href="https://github.com/nimuh/deep-learning" target="_blank" rel="noopener">
+          <div class="card-head">
+            <h3>Image Segmentation for Monocular Visual Odometry</h3>
+            <span class="arrow">↗</span>
+          </div>
+          <p>
+            Motivated by a vehicle-speed prediction challenge, this survey and implementation project
+            explored scene segmentation as a route to better visual odometry. I surveyed classical
+            segmentation approaches and fully implemented <a href="https://arxiv.org/abs/1511.00561" target="_blank" rel="noopener">SegNet</a>
+            in PyTorch, training on a GTX 1660 Super with Weights &amp; Biases for experiment tracking.
+          </p>
+          <div class="tags">
+            <span class="tag">computer vision</span>
+            <span class="tag">segmentation</span>
+            <span class="tag">PyTorch</span>
+          </div>
+        </a>
+      </div>
+    </section>
+
+    <footer>
+      <span>© <span id="year"></span> Nima Azbijari</span>
+      <span>Built with care · <a href="https://github.com/nimuh/nimuh.github.io" target="_blank" rel="noopener">source</a></span>
+    </footer>
+  </div>
+
+  <script>
+    document.getElementById("year").textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,236 @@
+:root {
+  --bg: #0b0c0e;
+  --bg-elev: #131519;
+  --border: #24272e;
+  --text: #e8e9ec;
+  --text-dim: #a1a5ad;
+  --text-faint: #6b6f78;
+  --accent: #5eead4;
+  --accent-dim: rgba(94, 234, 212, 0.12);
+  --radius: 14px;
+  --maxw: 720px;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+html { scroll-behavior: smooth; }
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.65;
+  -webkit-font-smoothing: antialiased;
+  font-feature-settings: "cv02", "cv03", "cv04", "cv11";
+  background-image: radial-gradient(circle at 50% -10%, rgba(94, 234, 212, 0.06), transparent 45%);
+  background-repeat: no-repeat;
+}
+
+a { color: var(--accent); text-decoration: none; transition: color .18s ease, opacity .18s ease; }
+a:hover { opacity: .82; }
+
+.wrap {
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+/* ---------- Nav ---------- */
+nav {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  backdrop-filter: blur(10px);
+  background: rgba(11, 12, 14, 0.72);
+  border-bottom: 1px solid var(--border);
+}
+nav .wrap {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 60px;
+}
+nav .brand { font-weight: 600; letter-spacing: -.01em; color: var(--text); text-decoration: none; }
+nav .brand:hover { opacity: 1; color: var(--text); }
+nav .links { display: flex; gap: 22px; font-size: .9rem; }
+nav .links a { color: var(--text-dim); }
+nav .links a:hover { color: var(--text); opacity: 1; }
+nav .links a.active { color: var(--accent); }
+@media (max-width: 560px) { nav .links { gap: 14px; font-size: .82rem; } }
+
+/* ---------- Page header ---------- */
+header.hero {
+  padding: 72px 0 40px;
+  display: flex;
+  align-items: center;
+  gap: 32px;
+}
+.avatar {
+  flex: 0 0 auto;
+  width: 116px;
+  height: 116px;
+  border-radius: 50%;
+  object-fit: cover;
+  object-position: center 22%;
+  border: 1px solid var(--border);
+  filter: grayscale(1) contrast(1.02);
+  transition: filter .3s ease;
+}
+.avatar:hover { filter: grayscale(0) contrast(1); }
+.hero h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  letter-spacing: -.02em;
+  line-height: 1.1;
+  margin-bottom: 8px;
+}
+.hero .role { color: var(--text-dim); font-size: 1.02rem; }
+.hero .socials { margin-top: 14px; display: flex; gap: 16px; font-size: .88rem; }
+.hero .socials a { color: var(--text-dim); display: inline-flex; align-items: center; gap: 6px; }
+.hero .socials a:hover { color: var(--accent); opacity: 1; }
+@media (max-width: 560px) {
+  header.hero { flex-direction: column; align-items: flex-start; gap: 22px; padding: 52px 0 32px; }
+  .hero h1 { font-size: 1.7rem; }
+}
+
+header.page-header {
+  padding: 64px 0 40px;
+}
+header.page-header h1 {
+  font-size: 1.9rem;
+  font-weight: 700;
+  letter-spacing: -.02em;
+  margin-bottom: 8px;
+}
+header.page-header p { font-size: 1rem; color: var(--text-dim); }
+
+/* ---------- Sections ---------- */
+section { padding: 30px 0; border-top: 1px solid var(--border); }
+.section-title {
+  font-size: .78rem;
+  text-transform: uppercase;
+  letter-spacing: .16em;
+  color: var(--text-faint);
+  font-weight: 600;
+  margin-bottom: 22px;
+}
+
+p { color: var(--text-dim); }
+p + p { margin-top: 14px; }
+
+/* ---------- Timeline entries ---------- */
+.entry { margin-bottom: 22px; }
+.entry:last-child { margin-bottom: 0; }
+.entry .top {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+.entry .title { font-weight: 600; color: var(--text); }
+.entry .date {
+  font-family: "JetBrains Mono", monospace;
+  font-size: .78rem;
+  color: var(--text-faint);
+  white-space: nowrap;
+}
+.entry .sub { color: var(--text-dim); font-size: .95rem; margin-top: 3px; }
+
+/* ---------- Cards ---------- */
+.cards { display: grid; gap: 14px; }
+.card {
+  display: block;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 22px 24px;
+  transition: border-color .2s ease, transform .2s ease, background .2s ease;
+}
+.card:hover {
+  border-color: rgba(94, 234, 212, 0.4);
+  background: #16191e;
+  transform: translateY(-2px);
+  opacity: 1;
+}
+.card .card-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+.card h3 {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--text);
+  letter-spacing: -.01em;
+}
+.card .arrow { color: var(--text-faint); transition: transform .2s ease, color .2s ease; }
+.card:hover .arrow { color: var(--accent); transform: translate(2px, -2px); }
+.card p { font-size: .92rem; line-height: 1.6; margin: 0; color: var(--text-dim); }
+
+/* non-link card variant */
+.card-static {
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 22px 24px;
+}
+.card-static h3 {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--text);
+  letter-spacing: -.01em;
+  margin-bottom: 8px;
+}
+.card-static p { font-size: .92rem; line-height: 1.6; color: var(--text-dim); }
+.card-static p + p { margin-top: 10px; }
+
+.tags { margin-top: 14px; display: flex; flex-wrap: wrap; gap: 8px; }
+.tag {
+  font-family: "JetBrains Mono", monospace;
+  font-size: .7rem;
+  color: var(--accent);
+  background: var(--accent-dim);
+  border: 1px solid rgba(94, 234, 212, 0.18);
+  padding: 3px 9px;
+  border-radius: 999px;
+}
+
+/* ---------- Status pill ---------- */
+.status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: "JetBrains Mono", monospace;
+  font-size: .7rem;
+  color: var(--accent);
+  background: var(--accent-dim);
+  border: 1px solid rgba(94, 234, 212, 0.18);
+  padding: 3px 10px;
+  border-radius: 999px;
+  margin-bottom: 14px;
+}
+.status .dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: pulse 2s ease-in-out infinite;
+}
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: .35; }
+}
+
+/* ---------- Footer ---------- */
+footer {
+  padding: 40px 0 60px;
+  border-top: 1px solid var(--border);
+  color: var(--text-faint);
+  font-size: .82rem;
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 10px;
+}


### PR DESCRIPTION
## Summary
- Adds `research.html` — a dedicated Research page with **Current** (protein LMs, GNNs at OSU) and **Past** sections (M.Sc. thesis, cancer risk prediction, image segmentation)
- Extracts all shared CSS into `style.css` used by both `index.html` and `research.html`
- Adds a **Research** nav link to `index.html`; makes the brand name a home link

## Test plan
- [ ] Visit the site and confirm the Research nav link appears and routes to `research.html`
- [ ] Verify the active state highlights "Research" in the nav on `research.html`
- [ ] Check both pages look consistent (same fonts, colors, card styles)
- [ ] Confirm mobile layout is intact on both pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)